### PR TITLE
Change AudioPlayer method call

### DIFF
--- a/docs/wiki/advanced-topics/playing-audio.md
+++ b/docs/wiki/advanced-topics/playing-audio.md
@@ -104,13 +104,13 @@ audioConnection.setAudioSource(source);
 playerManager.loadItem("https://www.youtube.com/watch?v=NvS351QKFV4", new AudioLoadResultHandler() {
     @Override
     public void trackLoaded(AudioTrack track) {
-        player.play(track);
+        player.playTrack(track);
     }
 
     @Override
     public void playlistLoaded(AudioPlaylist playlist) {
         for (AudioTrack track : playlist.getTracks()) {
-            player.play(track);
+            player.playTrack(track);
         }
     }
 


### PR DESCRIPTION
Lavaplayer seems to have updated their library such that it is no longer `AudioPlayer#play(AudioTrack track)`, but `AudioPlayer#playTrack(AudioTrack track)`. The bottom code block on the tutorial page should be updated accordingly.